### PR TITLE
Introductory argument mapping between libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ venv.bak/
 node_modules
 coverage
 .nyc_output
+
+# Editor
+*.code-workspace

--- a/docs-crawler/docs/aggregate_crawler_output.py
+++ b/docs-crawler/docs/aggregate_crawler_output.py
@@ -1,0 +1,44 @@
+import json
+import re
+
+
+class Compiler(object):
+    tf = []
+    tfjs = []
+    torch = []
+    main_map = {'tf': {}, 'tfjs': {}, 'torch': {}}
+    base_defs = set()
+
+    def __init__(self):
+        with open('./output/tf/2.1.json') as tf_file, \
+            open('./output/torch/1.4.0.json') as torch_file, \
+            open('./output/tfjs/1.5.1.json') as tfjs_file:
+            self.tf = json.load(tf_file)
+            self.tfjs = json.load(tfjs_file)
+            self.torch = json.load(torch_file)
+
+    def normalize_func_name(self, name):
+        alpha = re.compile('[^a-zA-Z]')
+        return alpha.sub('', name).lower()
+
+    def load_base_defs(self):
+        for f in self.tf:
+            nfunc = self.normalize_func_name(f['function_name'])
+            self.main_map['tf'][f['function_name']] = nfunc
+            self.base_defs.add(nfunc)
+        for f in self.tfjs:
+            nfunc = self.normalize_func_name(f['function_name'])
+            self.main_map['tfjs'][f['function_name']] = nfunc
+            self.base_defs.add(nfunc)
+        for f in self.torch:
+            nfunc = self.normalize_func_name(f['function_name'])
+            self.main_map['torch'][f['function_name']] = nfunc
+            self.base_defs.add(nfunc)
+
+def main():
+    c = Compiler()
+    c.load_base_defs()
+    print(c.main_map)
+
+if __name__ == '__main__':
+    main()

--- a/docs-crawler/docs/aggregate_crawler_output.py
+++ b/docs-crawler/docs/aggregate_crawler_output.py
@@ -24,21 +24,81 @@ class Compiler(object):
     def load_base_defs(self):
         for f in self.tf:
             nfunc = self.normalize_func_name(f['function_name'])
-            self.main_map['tf'][f['function_name']] = nfunc
+            f['args'] = self.hydrate_args(f['args'], f['kwargs'])
+            del f['kwargs']
+            self.main_map['tf'][nfunc] = f
             self.base_defs.add(nfunc)
         for f in self.tfjs:
             nfunc = self.normalize_func_name(f['function_name'])
-            self.main_map['tfjs'][f['function_name']] = nfunc
+            f['args'] = self.hydrate_args(f['args'], f['kwargs'])
+            del f['kwargs']
+            self.main_map['tfjs'][nfunc] = f
             self.base_defs.add(nfunc)
         for f in self.torch:
             nfunc = self.normalize_func_name(f['function_name'])
-            self.main_map['torch'][f['function_name']] = nfunc
+            f['args'] = self.hydrate_args(f['args'], f['kwargs'])
+            del f['kwargs']
+            self.main_map['torch'][nfunc] = f
             self.base_defs.add(nfunc)
+    
+    def hydrate_args(self, base_args, base_kwargs):
+        ba = [{
+            'name': self.normalize_func_name(a), 
+            'is_kwarg': False, 
+            'optional': a.endswith('?'), 
+            'index': i
+            } for i, a in enumerate(base_args)]
+        bk = [{
+            'name': self.normalize_func_name(a[0]), 
+            'is_kwarg': True, 
+            'optional': True
+            } for a in base_kwargs]
+        return ba + bk
+
+    
+    def match_arg_names(self, base, match, to_lang):
+        for base_arg in base:
+            try:
+                match_arg = next(m for m in match if m.get('name') == base_arg.get('name'))
+                base_arg[to_lang] = match_arg.get('name', None)
+            except:
+                # TODO: check for alternate word level translations
+                base_arg[to_lang] = None
+        return base
+
+
+    def load_translations(self, from_lang):
+        langs = ['torch', 'tfjs', 'tf']
+        langs.pop(langs.index(from_lang))
+
+        for d in self.base_defs:
+            # Check if translation exists in our from language
+            if d not in self.main_map[from_lang]:
+                continue
+
+            base_args = self.main_map[from_lang][d]['args']
+            # Check if translatable to other langs 
+            for to_lang in langs:
+                if d not in self.main_map[to_lang]:
+                    for a in self.main_map[from_lang][d]['args']:
+                        a.update({to_lang: None})
+                    continue 
+
+                # Format & match args
+                match_args = self.main_map[to_lang][d]['args']
+                self.main_map[from_lang][d]['args'] = self.match_arg_names(base_args, match_args, to_lang)
+
+    def output_data(self):
+        with open('output.json', 'w', encoding='utf8') as f:
+            json.dump(self.main_map, f, indent=4, ensure_ascii=False)
 
 def main():
     c = Compiler()
     c.load_base_defs()
-    print(c.main_map)
+    c.load_translations('tfjs')
+    c.load_translations('torch')
+    c.load_translations('tf')
+    c.output_data()
 
 if __name__ == '__main__':
     main()

--- a/docs-crawler/docs/docs/items.py
+++ b/docs-crawler/docs/docs/items.py
@@ -8,12 +8,6 @@
 import scrapy
 
 
-class DocsItem(scrapy.Item):
-    # define the fields for your item here like:
-    # name = scrapy.Field()
-    pass
-
-
 class ApiItem(scrapy.Item):
     code = scrapy.Field()
     function_name = scrapy.Field()


### PR DESCRIPTION
**Blocked by PR #24**

This should resolve #21 however, we will want to implement some word level translations so we can easilly map arguments like (`input -> a, other -> b`) and so on.

Translated arguments will be output as follows

```json
"histogramfixedwidth": {
            "code": "tf.histogram_fixed_width(values,value_range,nbins=100,dtype=tf.dtypes.int32,name=None)",
            "function_name": "histogram_fixed_width",
            "args": [
                {
                    "name": "values",
                    "is_kwarg": false,
                    "optional": false,
                    "index": 0,
                    "torch": null,
                    "tfjs": null
                },
                {
                    "name": "valuerange",
                    "is_kwarg": false,
                    "optional": false,
                    "index": 1,
                    "torch": null,
                    "tfjs": null
                },
                {
                    "name": "nbins",
                    "is_kwarg": true,
                    "optional": true,
                    "torch": null,
                    "tfjs": null
                },
                {
                    "name": "dtype",
                    "is_kwarg": true,
                    "optional": true,
                    "torch": null,
                    "tfjs": null
                },
                {
                    "name": "name",
                    "is_kwarg": true,
                    "optional": true,
                    "torch": null,
                    "tfjs": null
                }
            ]
        }
```