### PR TITLE
Make package consumable via npm+git

### DIFF
--- a/js/rollup.config.js
+++ b/js/rollup.config.js
@@ -6,7 +6,7 @@ import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import filesize from 'rollup-plugin-filesize';
 
-import pkg from './package.json';
+import pkg from '../package.json';
 
 const sharedOutput = {
   name: 'threepio',
@@ -18,7 +18,7 @@ const sharedOutput = {
 };
 
 export default {
-  input: 'src/index.js',
+  input: 'js/src/index.js',
   output: [
     {
       file: pkg.browser,

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1,4 +1,4 @@
 export * from './_constants';
 
 export { default as Threepio } from './threepio';
-export { default } from './threepio';
+export { default as Command } from './command';

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "jest": "jest --coverage",
     "lint": "xo",
     "nyc": "cross-env NODE_ENV=test nyc jest",
+    "prepare": "rollup --config js/rollup.config.js",
     "test": "npm run lint && jest",
     "test-coverage": "npm run lint && npm run nyc"
   },

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "test": "npm run lint && jest",
     "test-coverage": "npm run lint && npm run nyc"
   },
-  "type": "module",
   "xo": {
     "prettier": true,
     "space": true,


### PR DESCRIPTION
Several simple fixes that allow to install package via npm from git url and import it in the project.
