### PR TITLE
fix: index.esm.js is missing in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "node": ">=8.3"
   },
   "files": [
-    "./js/"
+    "js/dist/*.js"
   ],
   "homepage": "https://github.com/OpenMined/threepio",
   "husky": {


### PR DESCRIPTION
## Description
js/dist/index.esm.js was missing from dist folder after installing threepio as dependency via npm.
This was the reason syft.js's rollup build couldn't find and bundle threepio into syft.js.

## Affected Dependencies
syft.js

## How has this been tested?
Ran `npm i && npm run build` in syft.js

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
