### PR TITLE
feat: Adds initial docstring & comments to translations.py

### DIFF
--- a/docs-crawler/docs/translations.py
+++ b/docs-crawler/docs/translations.py
@@ -1,6 +1,6 @@
 """
 .. module:: docs
-   :synopsis: Contains dictionary containing keys and values for translating words & commands between frameworks
+   :synopsis: Contains variables to translate words/commands between frameworks
 """
 
 # dictionary containing values for translating words

--- a/docs-crawler/docs/translations.py
+++ b/docs-crawler/docs/translations.py
@@ -1,3 +1,9 @@
+  """
+.. module:: docs
+   :synopsis: Contains dictionary containing keys and values for translating words & commands between frameworks
+"""
+
+# dictionary containing values for translating words
 WORD_TRANSLATIONS = {
     'tfjs': {
         'dim': 'axis',
@@ -11,6 +17,7 @@ WORD_TRANSLATIONS = {
     'tf': {}
 }
 
+# dictionary containing values for translating commands
 COMMAND_TRANSLATIONS = {
     'tf': {},
     'tfjs': {},

--- a/docs-crawler/docs/translations.py
+++ b/docs-crawler/docs/translations.py
@@ -1,4 +1,4 @@
-  """
+"""
 .. module:: docs
    :synopsis: Contains dictionary containing keys and values for translating words & commands between frameworks
 """


### PR DESCRIPTION
Would resolve Issue #75

## Description
Adds docstring & inline comments to translations.py

## Affected Dependencies
None

## How has this been tested?
- Viewed via the GitHub in the browser

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
