### PR TITLE
Inline docs for threepio.py

### DIFF
--- a/pythreepio/pythreepio/command.py
+++ b/pythreepio/pythreepio/command.py
@@ -1,6 +1,5 @@
 import sys
 from typing import Callable
-from pythreepio.errors import TranslationMissing
 
 
 class Placeholder(object):

--- a/pythreepio/pythreepio/threepio.py
+++ b/pythreepio/pythreepio/threepio.py
@@ -7,25 +7,67 @@ from .command import Command, cmd_from_info
 
 
 class Threepio(object):
+    """
+    Threepio Class to translate a command from one framework to another.
+
+    :param from_lang: Framework to convert from
+    :type from_lang: str
+    :param to_lang: Framework to convert to
+    :type to_lang: str
+    :param framework: Framework to convert to
+    :type framework: object
+    """
+
     def __init__(self, from_lang: str, to_lang: str, framework: object):
+        """Initialize a Threepio object to translate commands."""
+
+        # Fetch a dictionary of mapped commands between frameworks
         self.commands = get_mapped_commands()
+        # Assert framework to convert from is present in mapped commands
         assert from_lang in self.commands, f"\"{from_lang}\" is not in the mapped commands."
         self.from_lang = from_lang
         self.to_lang = to_lang
         self.framework = framework
 
-    def _normalize_func_name(self, name: str, lang: str) -> str:
+    def _normalize_func_name(self, name: str) -> str:
+        """Normalizes a function name to lower case and keep only alphabets
+
+        :param name: function name to normalize
+        :type name: str
+
+        :return: returns a string converted to lowercase keeping only alphabets
+        :rtype: str
+        """
         alpha = re.compile("[^a-zA-Z]")
         return alpha.sub("", name).lower()
 
     def _order_args(
         self, cmd: Command, from_info: dict, to_info: dict
     ) -> Tuple[list, dict]:
+        """Extracts and orders the args and kwargs according to translated command
+
+        :param cmd: command to be translated
+        :type cmd: Command
+        :param from_info: Dictionary of info for the command for the `from` framework
+        :type from_info: dict
+        :param to_info: Dictionary of info for the command for the `to` framework
+        :type to_info: dict
+
+        :return: Returns ordered - args and kwargs
+        :rtype:  Tuple[list, dict]
+        """
         new_args = []
         new_kwargs = {}
 
         def get_to_arg_index(from_arg):
-            """Returns index for the original argument in the translated command arguments list"""
+            """Returns index for the original argument in the translated command arguments list
+
+            :param from_arg: info of ith argument of 'from' framework
+            :type from_arg: dict
+
+            :return: returns the index of original argument or None
+            :rtype:  int or None
+            """
             return next(
                 (
                     index
@@ -35,14 +77,20 @@ class Threepio(object):
                 None,
             )
 
+        # Loop through the command arguments For eg. Tensors to perform operation to
         for i, arg in enumerate(cmd.args):
+            # Extract the info of ith argument of `from` framework
             from_arg = from_info["args"][i]
+            # Check if the same name argument is present in `to` framework
+            # If yes, get its index
             to_arg_index = get_to_arg_index(from_arg)
 
+            # Append arguments which don't have same name between frameworks
             if to_arg_index is None:
                 new_args.append(arg)
                 continue
 
+            # Append arguments with same names at the proper position of the `to` framework
             new_args.insert(to_arg_index, arg)
 
         # Add static args, if any
@@ -54,6 +102,7 @@ class Threepio(object):
 
         # If any kwargs are normal args, splice them in as well
         for k, v in cmd.kwargs.items():
+            # Map kwargs similarly if provided
             from_arg = [a for a in from_info["args"] if a["name"] == k][0]
             to_arg_index = next(
                 (
@@ -73,28 +122,55 @@ class Threepio(object):
         return new_args, new_kwargs
 
     def translate_multi(self, orig_cmd, commands_info):
+        """Translates command which has multiple translated chained commands
+
+        :param orig_cmd: command to be translated
+        :type orig_cmd: Command
+        :param commands_info: chained commmands with info
+        :type commands_info: list
+
+        :return: Returns translated commands
+        :rtype:  list
+        """
         cmd_config = commands_info.pop(0)
         store = {}
         for i, arg in enumerate(orig_cmd.args):
+            # Store the command arguments
             cmd_config["args"][i]["value"] = arg
             store[cmd_config["args"][i]["name"]] = arg
 
         new_cmds = [cmd_config]
         for from_info in commands_info:
+            # Creates a command given info and arguments with values
             cmd = cmd_from_info(from_info, store)
+
+            # Get the info of the command for the framework we want to convert to with the new alias of the command
             to_info = self.commands[self.to_lang][
-                self._normalize_func_name(from_info.get(self.to_lang), self.to_lang)
+                self._normalize_func_name(from_info.get(self.to_lang))
             ][0]
 
             new_cmds.append(self.translate_command(cmd, from_info, to_info))
         return new_cmds
 
     def translate_command(self, cmd, from_command, to_command):
-        attrs = to_command["attrs"][1:]
+        """Translates a Command Object after knowing it exists in both frameworks
+
+        :param cmd: command to be translated
+        :type cmd: Command
+        :param from_command: Dictionary of info for the command for the `from` framework
+        :type from_command: dict
+        :param to_command: Dictionary of info for the command for the `to` framework
+        :type to_command: dict
+
+        :return: returns a list of translated commands
+        :rtype: list
+        """
+
         translated_cmd = None
+        # Extracts and orders the args and kwargs according to translated command
         args, kwargs = self._order_args(cmd, from_command, to_command)
         output = from_command.get("placeholder_output", None)
-
+        # Return a new Command object created after translation with ordered args and kwargs
         return Command(
             to_command["name"],
             args,
@@ -104,22 +180,37 @@ class Threepio(object):
             exec_fn=translated_cmd,
         )
 
-    def translate(self, cmd: Command, lookup_command: bool = False) -> List[Command]:
-        normalized_func_name = self._normalize_func_name(cmd.function_name, self.from_lang)
+    def translate(self, cmd: Command) -> List[Command]:
+        """Translates a Command Object
+
+        :param cmd: command to be translated
+        :type cmd: Command
+
+        :return: returns a list of translated command/s
+        :rtype: list
+        """
+
+        # Normalize the function name
+        normalized_func_name = self._normalize_func_name(cmd.function_name)
+        # Get the info of the command from the framework to be translated from
         from_info = self.commands[self.from_lang].get(normalized_func_name)
+        # Throw Exception if the command does not exist in the framework to be translated from
         if from_info is None:
             raise TranslationMissing(cmd.function_name)
-
+        # Check if translated command has multiple chained commands
         if len(from_info) > 1:
             return self.translate_multi(cmd, from_info)
 
+        # Extract the info since there is only one command
         from_info = from_info[0]
 
+        # Check if the alias of the command exists in the framework to translate to
         if from_info.get(self.to_lang, None) is None:
             raise TranslationMissing(cmd.function_name)
 
+        # Get the info of the command for the framework we want to convert to with the new alias of the command
         to_info = self.commands[self.to_lang][
-            self._normalize_func_name(from_info.get(self.to_lang), self.to_lang)
+            self._normalize_func_name(from_info.get(self.to_lang))
         ]
 
         return [self.translate_command(cmd, from_info, to_info[0])]

--- a/pythreepio/pythreepio/threepio.py
+++ b/pythreepio/pythreepio/threepio.py
@@ -14,7 +14,7 @@ class Threepio(object):
     :type from_lang: str
     :param to_lang: Framework to convert to
     :type to_lang: str
-    :param framework: Framework to convert to
+    :param framework: Reference to package that represents to_lang
     :type framework: object
     """
 

--- a/pythreepio/pythreepio/utils.py
+++ b/pythreepio/pythreepio/utils.py
@@ -8,7 +8,7 @@ import static
 
 def get_mapped_commands() -> dict:
     """Returns dictionary of mapped commands from mapped_commands_full.json
-        
+
     :return: Dictionary of mapped commands
     :rtype: dict
     """

--- a/pythreepio/tests/fixtures/tfjs.py
+++ b/pythreepio/tests/fixtures/tfjs.py
@@ -11,15 +11,15 @@ abs_torch = {
     "answers": [[torch.Tensor([1, 2, 3, 4])]],
 }
 
-t1 = torch.Tensor([[[1,2], [3,4]], [[5,6], [7,8]]])
+t1 = torch.Tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
 select = {
-  "inputs": [Command("select", [
-    t1,
-    0,
-    1
-  ],
-                     {})],
-  "answers": [Command("gather", [t1, 1, 0], {}, ["tf", "gather"])],
+    "inputs": [Command("select", [
+        t1,
+        0,
+        1
+    ],
+        {})],
+    "answers": [Command("gather", [t1, 1, 0], {}, ["tf", "gather"])],
 }
 
 t1 = torch.Tensor([1, -2, 3, -4])

--- a/pythreepio/tests/test_torch_tf.py
+++ b/pythreepio/tests/test_torch_tf.py
@@ -67,7 +67,7 @@ def test_translates_sum(torch_threepio):
 
 def test_translates_linear(torch_threepio):
     for i, input_cmd in enumerate(linear["inputs"]):
-        translations = torch_threepio.translate(input_cmd, lookup_command=True)
+        translations = torch_threepio.translate(input_cmd)
         translations.pop(0)
         # Create a store for command outputs
         store = {}

--- a/pythreepio/tests/test_torch_tfjs.py
+++ b/pythreepio/tests/test_torch_tfjs.py
@@ -25,14 +25,14 @@ def test_translation_missing(tfjs_threepio):
 
 def test_translates_tfjs_abs(tfjs_threepio):
     for i, input in enumerate(tfjs_abs["inputs"]):
-        translations = tfjs_threepio.translate(input, lookup_command=True)
+        translations = tfjs_threepio.translate(input)
         for translation in translations:
             assert translation.attrs == tfjs_abs["answers"][i]
 
 
 def test_translates_tfjs_to_float(tfjs_threepio):
     for i, input in enumerate(tfjs_to_float["inputs"]):
-        translations = tfjs_threepio.translate(input, lookup_command=True)
+        translations = tfjs_threepio.translate(input)
         for translation in translations:
             assert translation.function_name == tfjs_to_float["answers"][i].function_name
             assert translation.args == tfjs_to_float["answers"][i].args
@@ -42,7 +42,7 @@ def test_translates_tfjs_to_float(tfjs_threepio):
 
 def test_translates_tfjs_rsub(tfjs_threepio):
     for input, answer in zip(tfjs_rsub["inputs"], tfjs_rsub["answers"]):
-        translations = tfjs_threepio.translate(input, lookup_command=True)
+        translations = tfjs_threepio.translate(input)
         for translation in translations:
             assert translation.function_name == answer.function_name
             assert translation.args == answer.args
@@ -52,7 +52,7 @@ def test_translates_tfjs_rsub(tfjs_threepio):
 
 def test_translates_tfjs_rtruediv(tfjs_threepio):
     for i, input in enumerate(tfjs_rtruediv["inputs"]):
-        translations = tfjs_threepio.translate(input, lookup_command=True)
+        translations = tfjs_threepio.translate(input)
         for translation in translations:
             assert translation.function_name == tfjs_rtruediv["answers"][i].function_name
             assert translation.args == tfjs_rtruediv["answers"][i].args
@@ -61,20 +61,20 @@ def test_translates_tfjs_rtruediv(tfjs_threepio):
 
 
 def test_translates_tfjs_reshape(tfjs_threepio):
-  for i, input in enumerate(tfjs_reshape["inputs"]):
-    translations = tfjs_threepio.translate(input, lookup_command=True)
-    for translation in translations:
-      assert translation.function_name == tfjs_reshape["answers"][i].function_name
-      assert translation.args == tfjs_reshape["answers"][i].args
-      assert translation.kwargs == tfjs_reshape["answers"][i].kwargs
-      assert translation.attrs == tfjs_reshape["answers"][i].attrs
+    for i, input in enumerate(tfjs_reshape["inputs"]):
+        translations = tfjs_threepio.translate(input)
+        for translation in translations:
+            assert translation.function_name == tfjs_reshape["answers"][i].function_name
+            assert translation.args == tfjs_reshape["answers"][i].args
+            assert translation.kwargs == tfjs_reshape["answers"][i].kwargs
+            assert translation.attrs == tfjs_reshape["answers"][i].attrs
 
 
 def test_translates_tfjs_select(tfjs_threepio):
-  for cmd, answer in zip(tfjs_select["inputs"], tfjs_select["answers"]):
-    translations = tfjs_threepio.translate(cmd, lookup_command=True)
-    for translation in translations:
-      assert translation.function_name == answer.function_name
-      assert translation.args == answer.args
-      assert translation.kwargs == answer.kwargs
-      assert translation.attrs == answer.attrs
+    for cmd, answer in zip(tfjs_select["inputs"], tfjs_select["answers"]):
+        translations = tfjs_threepio.translate(cmd)
+        for translation in translations:
+            assert translation.function_name == answer.function_name
+            assert translation.args == answer.args
+            assert translation.kwargs == answer.kwargs
+            assert translation.attrs == answer.attrs

--- a/pythreepio/tests/util.py
+++ b/pythreepio/tests/util.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 
 def process_tests(command, threepio, check_answer):
     for i, input in enumerate(command["inputs"]):
-        translations = threepio.translate(input, lookup_command=True)
+        translations = threepio.translate(input)
         for j, translation in enumerate(translations):
             result = translation.execute_routine()
             answer = command["answers"][i][j]


### PR DESCRIPTION
## Description
- Added inline documentation and docstrings for threepio.py
- Fixed flake8 warnings
- removed deprecated function parameters

Resolves #69 

> I have followed restructured text format to document the code same as Pysyft docs

## Affected Dependencies
None

## How has this been tested?
Passed pytest and flake8 as described in the workflow file.

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
